### PR TITLE
Include git branch name in default prompt

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -1,5 +1,9 @@
 #!/usr/bin/env fish
 
+function parse_git_branch
+    git branch 2> /dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/(\1)/'
+end
+
 function fish_prompt
     set_color purple
     set -l d (string replace $HOME "~" $PWD)
@@ -8,7 +12,7 @@ function fish_prompt
     else if [ $d = "/" ]
         printf "/ "
     else
-        echo $d
+        echo $d (parse_git_branch)
     end
     set_color green
     echo "➜ "


### PR DESCRIPTION
Added function that finds out the current branch name.
Include branch name in default prompt. Closes #1 

Let me know if you want to cover the cases where ~ is a git repository as well.